### PR TITLE
Add checklists to intake cards when moved to IAA Go

### DIFF
--- a/actions/add-intake-checklist.js
+++ b/actions/add-intake-checklist.js
@@ -8,10 +8,10 @@ module.exports = function addIntakeChecklist(cardID) {
   let checklistID;
   return trello.get(`/1/cards/${cardID}/checklists`)
   .then(checklists => {
-    if(checklists.filter(list => list.name === checklistName).length) {
+    if (checklists.some(list => list.name === checklistName)) {
       throw new Error('Intake card already has an intake forms checklist');
     }
-    
+
     return trello.post('/1/checklists', {
       idCard: cardID,
       name: checklistName
@@ -22,9 +22,5 @@ module.exports = function addIntakeChecklist(cardID) {
       name: '7600 SOW'
     });
   })
-  .then(() => {
-    return trello.post(`/1/checklists/${checklistID}/checkItems`, {
-      name: 'Budget Estimate'
-    });
-  });
+  .then(() => trello.post(`/1/checklists/${checklistID}/checkItems`, { name: 'Budget Estimate' }));
 };

--- a/actions/add-intake-checklist.js
+++ b/actions/add-intake-checklist.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const trello = require('../trello');
+
+const checklistName = 'Intake Forms';
+
+module.exports = function addIntakeChecklist(cardID) {
+  let checklistID;
+  return trello.get(`/1/cards/${cardID}/checklists`)
+  .then(checklists => {
+    if(checklists.filter(list => list.name === checklistName).length) {
+      throw new Error('Intake card already has an intake forms checklist');
+    }
+    
+    return trello.post('/1/checklists', {
+      idCard: cardID,
+      name: checklistName
+    });
+  }).then(checklist => {
+    checklistID = checklist.id;
+    return trello.post(`/1/checklists/${checklistID}/checkItems`, {
+      name: '7600 SOW'
+    });
+  })
+  .then(() => {
+    return trello.post(`/1/checklists/${checklistID}/checkItems`, {
+      name: 'Budget Estimate'
+    });
+  });
+};

--- a/actions/index.js
+++ b/actions/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const addIntakeChecklist = require('./add-intake-checklist');
 const createBPAOrderBoard = require('./create-bpa-order-board');
 const createBPAOrderCard = require('./create-bpa-order-card');
 const createATCCard = require('./create-atc-card');
 
 module.exports = {
+  addIntakeChecklist,
   createATCCard,
   createBPAOrderBoard,
   createBPAOrderCard

--- a/test/actions/add-intake-checklist.js
+++ b/test/actions/add-intake-checklist.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const tap = require('tap');
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+process.env.TRELLO_API_KEY = 'trello-api-key';
+process.env.TRELLO_API_TOK = 'trello-api-tok';
+
+const trello = require('../../trello');
+const sandbox = sinon.sandbox.create();
+const trelloGet = sandbox.stub(trello, 'get');
+const trelloPost = sandbox.stub(trello, 'post');
+
+const addIntakeChecklist = require('../../actions/add-intake-checklist');
+const intakeCardID = 'intake-card-id';
+
+// Disable logging to the console.
+require('@erdc-itl/simple-logger').setOptions({ console: false });
+
+tap.test('actions - add intake checklist', t1 => {
+  t1.beforeEach(done => {
+    sandbox.reset();
+    done();
+  });
+
+  t1.teardown(() => {
+    sandbox.restore();
+  });
+
+  t1.test('trello get throws error (fetching existing checklists)', t2 => {
+    const err = new Error('Test error');
+    trelloGet.rejects(err);
+
+    addIntakeChecklist(intakeCardID)
+      .then(() => {
+        t2.fail('rejects');
+      })
+      .catch(e => {
+        t2.pass('rejects');
+        t2.equals(trelloGet.callCount, 1, 'trello get called one time');
+        t2.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+        t2.equals(trelloPost.callCount, 0, 'trello post called 0 times');
+        t2.equals(e, err, 'returns the expected error');
+      })
+      .then(t2.done);
+  });
+
+  t1.test('trello get returns a list of checklists include intake forms', t2 => {
+    trelloGet.resolves([{ name: 'Intake Forms' }]);
+
+    addIntakeChecklist(intakeCardID)
+      .then(() => {
+        t2.fail('rejects');
+      })
+      .catch(e => {
+        t2.pass('rejects');
+        t2.equals(trelloGet.callCount, 1, 'trello get called one time');
+        t2.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+        t2.equals(trelloPost.callCount, 0, 'trello post called 0 times');
+        t2.equals(e.message, 'Intake card already has an intake forms checklist', 'returns the expected error');
+      })
+      .then(t2.done);
+  });
+
+  const getPassValues = [
+    { name: 'empty list', value: [ ] },
+    { name: 'list without intake checklist', value: [{ name: 'Not intake' }] }
+  ];
+
+  getPassValues.forEach(getPass => {
+    t1.test(`trello get returns ${getPass.name}`, t2 => {
+      const expectedChecklistReq = {
+        idCard: intakeCardID,
+        name: 'Intake Forms'
+      };
+
+      t2.test('trello post (create checklist) rejects', t3 => {
+        const err = new Error('Test error');
+        trelloGet.resolves(getPass.value);
+        trelloPost.onCall(0).rejects(err);
+
+        addIntakeChecklist(intakeCardID)
+          .then(() => {
+            t3.fail('rejects');
+          })
+          .catch(e => {
+            t3.pass('rejects');
+            t3.equals(trelloGet.callCount, 1, 'trello get called one time');
+            t3.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+            t3.equals(trelloPost.callCount, 1, 'trello post called one time');
+            t3.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
+            t3.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
+            t3.equals(e, err, 'returns the expected error');
+          })
+          .then(t3.done);
+      });
+
+      t2.test('trello post (create checklist) resolves', t3 => {
+        const checklistID = 'checklist-id';
+
+        t3.test('trello post (add first item) rejects', t4 => {
+          const err = new Error('Test error');
+          trelloGet.resolves(getPass.value);
+          trelloPost.onCall(0).resolves({ id: checklistID });
+          trelloPost.onCall(1).rejects(err);
+
+          addIntakeChecklist(intakeCardID)
+            .then(() => {
+              t4.fail('rejects');
+            })
+            .catch(e => {
+              t4.pass('rejects');
+              t4.equals(trelloGet.callCount, 1, 'trello get called one time');
+              t4.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+              t4.equals(trelloPost.callCount, 2, 'trello post called two times');
+              t4.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
+              t4.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
+              t4.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+              t4.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
+              t4.equals(e, err, 'returns the expected error');
+            })
+            .then(t4.done);
+        });
+
+        t3.test('trello post (add first item) resolves', t4 => {
+          t4.test('trello post (add second item) rejects', t5 => {
+            const err = new Error('Test error');
+            trelloGet.resolves(getPass.value);
+            trelloPost.onCall(0).resolves({ id: checklistID });
+            trelloPost.onCall(1).resolves();
+            trelloPost.onCall(2).rejects(err);
+
+            addIntakeChecklist(intakeCardID)
+              .then(() => {
+                t5.fail('rejects');
+              })
+              .catch(e => {
+                t5.pass('rejects');
+                t5.equals(trelloGet.callCount, 1, 'trello get called one time');
+                t5.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+                t5.equals(trelloPost.callCount, 3, 'trello post called three times');
+                t5.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
+                t5.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
+                t5.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+                t5.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
+                t5.equals(trelloPost.args[2][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+                t5.same(trelloPost.args[2][1], { name: 'Budget Estimate' }, 'sends the expected arguments');
+                t5.equals(e, err, 'returns the expected error');
+              })
+              .then(t5.done);
+          });
+
+          t4.test('trello post (add second item) resolves', t5 => {
+            const err = new Error('Test error');
+            trelloGet.resolves(getPass.value);
+            trelloPost.onCall(0).resolves({ id: checklistID });
+            trelloPost.onCall(1).resolves();
+            trelloPost.onCall(2).resolves();
+
+            addIntakeChecklist(intakeCardID)
+              .then(() => {
+                t5.pass('resolves');
+                t5.equals(trelloGet.callCount, 1, 'trello get called one time');
+                t5.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+                t5.equals(trelloPost.callCount, 3, 'trello post called three times');
+                t5.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
+                t5.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
+                t5.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+                t5.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
+                t5.equals(trelloPost.args[2][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+                t5.same(trelloPost.args[2][1], { name: 'Budget Estimate' }, 'sends the expected arguments');
+              })
+              .catch(e => {
+                t5.fail('resolves');
+              })
+              .then(t5.done);
+          });
+
+          t4.done();
+        });
+
+        t3.done();
+      });
+
+      t2.done();
+    });
+  });
+
+  t1.done();
+});

--- a/test/actions/add-intake-checklist.js
+++ b/test/actions/add-intake-checklist.js
@@ -18,49 +18,49 @@ const intakeCardID = 'intake-card-id';
 // Disable logging to the console.
 require('@erdc-itl/simple-logger').setOptions({ console: false });
 
-tap.test('actions - add intake checklist', t1 => {
-  t1.beforeEach(done => {
-    sandbox.reset();
-    done();
-  });
+tap.beforeEach(done => {
+  sandbox.reset();
+  done();
+});
 
-  t1.teardown(() => {
-    sandbox.restore();
-  });
+tap.teardown(() => {
+  sandbox.restore();
+});
 
-  t1.test('trello get throws error (fetching existing checklists)', t2 => {
+tap.test('actions - add intake checklist', trelloGetTest => {
+  trelloGetTest.test('trello get throws error (fetching existing checklists)', test => {
     const err = new Error('Test error');
     trelloGet.rejects(err);
 
     addIntakeChecklist(intakeCardID)
       .then(() => {
-        t2.fail('rejects');
+        test.fail('rejects');
       })
       .catch(e => {
-        t2.pass('rejects');
-        t2.equals(trelloGet.callCount, 1, 'trello get called one time');
-        t2.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
-        t2.equals(trelloPost.callCount, 0, 'trello post called 0 times');
-        t2.equals(e, err, 'returns the expected error');
+        test.pass('rejects');
+        test.equals(trelloGet.callCount, 1, 'trello get called one time');
+        test.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+        test.equals(trelloPost.callCount, 0, 'trello post called 0 times');
+        test.equals(e, err, 'returns the expected error');
       })
-      .then(t2.done);
+      .then(test.done);
   });
 
-  t1.test('trello get returns a list of checklists include intake forms', t2 => {
+  trelloGetTest.test('trello get returns a list of checklists include intake forms', test => {
     trelloGet.resolves([{ name: 'Intake Forms' }]);
 
     addIntakeChecklist(intakeCardID)
       .then(() => {
-        t2.fail('rejects');
+        test.fail('rejects');
       })
       .catch(e => {
-        t2.pass('rejects');
-        t2.equals(trelloGet.callCount, 1, 'trello get called one time');
-        t2.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
-        t2.equals(trelloPost.callCount, 0, 'trello post called 0 times');
-        t2.equals(e.message, 'Intake card already has an intake forms checklist', 'returns the expected error');
+        test.pass('rejects');
+        test.equals(trelloGet.callCount, 1, 'trello get called one time');
+        test.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+        test.equals(trelloPost.callCount, 0, 'trello post called 0 times');
+        test.equals(e.message, 'Intake card already has an intake forms checklist', 'returns the expected error');
       })
-      .then(t2.done);
+      .then(test.done);
   });
 
   const getPassValues = [
@@ -69,37 +69,37 @@ tap.test('actions - add intake checklist', t1 => {
   ];
 
   getPassValues.forEach(getPass => {
-    t1.test(`trello get returns ${getPass.name}`, t2 => {
+    trelloGetTest.test(`trello get returns ${getPass.name}`, trelloPostChecklistTest => {
       const expectedChecklistReq = {
         idCard: intakeCardID,
         name: 'Intake Forms'
       };
 
-      t2.test('trello post (create checklist) rejects', t3 => {
+      trelloPostChecklistTest.test('trello post (create checklist) rejects', test => {
         const err = new Error('Test error');
         trelloGet.resolves(getPass.value);
         trelloPost.onCall(0).rejects(err);
 
         addIntakeChecklist(intakeCardID)
           .then(() => {
-            t3.fail('rejects');
+            test.fail('rejects');
           })
           .catch(e => {
-            t3.pass('rejects');
-            t3.equals(trelloGet.callCount, 1, 'trello get called one time');
-            t3.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
-            t3.equals(trelloPost.callCount, 1, 'trello post called one time');
-            t3.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
-            t3.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
-            t3.equals(e, err, 'returns the expected error');
+            test.pass('rejects');
+            test.equals(trelloGet.callCount, 1, 'trello get called one time');
+            test.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+            test.equals(trelloPost.callCount, 1, 'trello post called one time');
+            test.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
+            test.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
+            test.equals(e, err, 'returns the expected error');
           })
-          .then(t3.done);
+          .then(test.done);
       });
 
-      t2.test('trello post (create checklist) resolves', t3 => {
+      trelloPostChecklistTest.test('trello post (create checklist) resolves', trelloPostFirstCheckItemTest => {
         const checklistID = 'checklist-id';
 
-        t3.test('trello post (add first item) rejects', t4 => {
+        trelloPostFirstCheckItemTest.test('trello post (add first item) rejects', test => {
           const err = new Error('Test error');
           trelloGet.resolves(getPass.value);
           trelloPost.onCall(0).resolves({ id: checklistID });
@@ -107,24 +107,24 @@ tap.test('actions - add intake checklist', t1 => {
 
           addIntakeChecklist(intakeCardID)
             .then(() => {
-              t4.fail('rejects');
+              test.fail('rejects');
             })
             .catch(e => {
-              t4.pass('rejects');
-              t4.equals(trelloGet.callCount, 1, 'trello get called one time');
-              t4.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
-              t4.equals(trelloPost.callCount, 2, 'trello post called two times');
-              t4.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
-              t4.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
-              t4.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
-              t4.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
-              t4.equals(e, err, 'returns the expected error');
+              test.pass('rejects');
+              test.equals(trelloGet.callCount, 1, 'trello get called one time');
+              test.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+              test.equals(trelloPost.callCount, 2, 'trello post called two times');
+              test.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
+              test.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
+              test.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+              test.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
+              test.equals(e, err, 'returns the expected error');
             })
-            .then(t4.done);
+            .then(test.done);
         });
 
-        t3.test('trello post (add first item) resolves', t4 => {
-          t4.test('trello post (add second item) rejects', t5 => {
+        trelloPostFirstCheckItemTest.test('trello post (add first item) resolves', trelloPostSecondCheckItemTest => {
+          trelloPostSecondCheckItemTest.test('trello post (add second item) rejects', test => {
             const err = new Error('Test error');
             trelloGet.resolves(getPass.value);
             trelloPost.onCall(0).resolves({ id: checklistID });
@@ -133,25 +133,25 @@ tap.test('actions - add intake checklist', t1 => {
 
             addIntakeChecklist(intakeCardID)
               .then(() => {
-                t5.fail('rejects');
+                test.fail('rejects');
               })
               .catch(e => {
-                t5.pass('rejects');
-                t5.equals(trelloGet.callCount, 1, 'trello get called one time');
-                t5.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
-                t5.equals(trelloPost.callCount, 3, 'trello post called three times');
-                t5.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
-                t5.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
-                t5.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
-                t5.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
-                t5.equals(trelloPost.args[2][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
-                t5.same(trelloPost.args[2][1], { name: 'Budget Estimate' }, 'sends the expected arguments');
-                t5.equals(e, err, 'returns the expected error');
+                test.pass('rejects');
+                test.equals(trelloGet.callCount, 1, 'trello get called one time');
+                test.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+                test.equals(trelloPost.callCount, 3, 'trello post called three times');
+                test.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
+                test.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
+                test.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+                test.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
+                test.equals(trelloPost.args[2][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+                test.same(trelloPost.args[2][1], { name: 'Budget Estimate' }, 'sends the expected arguments');
+                test.equals(e, err, 'returns the expected error');
               })
-              .then(t5.done);
+              .then(test.done);
           });
 
-          t4.test('trello post (add second item) resolves', t5 => {
+          trelloPostSecondCheckItemTest.test('trello post (add second item) resolves', test => {
             const err = new Error('Test error');
             trelloGet.resolves(getPass.value);
             trelloPost.onCall(0).resolves({ id: checklistID });
@@ -160,32 +160,32 @@ tap.test('actions - add intake checklist', t1 => {
 
             addIntakeChecklist(intakeCardID)
               .then(() => {
-                t5.pass('resolves');
-                t5.equals(trelloGet.callCount, 1, 'trello get called one time');
-                t5.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
-                t5.equals(trelloPost.callCount, 3, 'trello post called three times');
-                t5.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
-                t5.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
-                t5.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
-                t5.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
-                t5.equals(trelloPost.args[2][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
-                t5.same(trelloPost.args[2][1], { name: 'Budget Estimate' }, 'sends the expected arguments');
+                test.pass('resolves');
+                test.equals(trelloGet.callCount, 1, 'trello get called one time');
+                test.equals(trelloGet.args[0][0], `/1/cards/${intakeCardID}/checklists`, 'calls the expected URL');
+                test.equals(trelloPost.callCount, 3, 'trello post called three times');
+                test.equals(trelloPost.args[0][0], `/1/checklists`, 'calls the expected URL');
+                test.same(trelloPost.args[0][1], expectedChecklistReq, 'sends the expected arguments');
+                test.equals(trelloPost.args[1][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+                test.same(trelloPost.args[1][1], { name: '7600 SOW' }, 'sends the expected arguments');
+                test.equals(trelloPost.args[2][0], `/1/checklists/${checklistID}/checkItems`, 'calls the expected URL');
+                test.same(trelloPost.args[2][1], { name: 'Budget Estimate' }, 'sends the expected arguments');
               })
               .catch(e => {
-                t5.fail('resolves');
+                test.fail('resolves');
               })
-              .then(t5.done);
+              .then(test.done);
           });
 
-          t4.done();
+          trelloPostSecondCheckItemTest.done();
         });
 
-        t3.done();
+        trelloPostFirstCheckItemTest.done();
       });
 
-      t2.done();
+      trelloPostChecklistTest.done();
     });
   });
 
-  t1.done();
+  trelloGetTest.done();
 });

--- a/test/webhookHandlers/move-to-iaa-go.js
+++ b/test/webhookHandlers/move-to-iaa-go.js
@@ -9,7 +9,7 @@ process.env.TRELLO_API_KEY = 'trello-api-key';
 process.env.TRELLO_API_TOK = 'trello-api-tok';
 
 const sandbox = sinon.sandbox.create();
-const addIntakeChecklist = sandbox.stub().resolves();
+const addIntakeChecklist = sandbox.stub();
 const createATCCard = sandbox.stub();
 const createBPAComponents = sandbox.stub();
 
@@ -98,9 +98,9 @@ tap.test('webhook handlers - intake: move to IAA Go', t1 => {
         }
       };
 
-      t3.test('createATCCard rejects', t4 => {
+      t3.test('addIntakeChecklist rejects', t4 => {
         const err = new Error('Test error');
-        createATCCard.rejects(err);
+        addIntakeChecklist.rejects(err);
 
         moveToiaaGo(trelloEvent)
           .then(() => {
@@ -113,11 +113,11 @@ tap.test('webhook handlers - intake: move to IAA Go', t1 => {
           .then(t4.done);
       });
 
-      t3.test('createATCCard resolves', t4 => {
-        t4.test('createBPAComponents rejects', t5 => {
+      t3.test('addIntakeChecklist resolves', t4 => {
+        t4.test('createATCCard rejects', t5 => {
           const err = new Error('Test error');
-          createATCCard.resolves();
-          createBPAComponents.rejects(err);
+          addIntakeChecklist.resolves();
+          createATCCard.rejects(err);
 
           moveToiaaGo(trelloEvent)
             .then(() => {
@@ -130,18 +130,40 @@ tap.test('webhook handlers - intake: move to IAA Go', t1 => {
             .then(t5.done);
         });
 
-        t4.test('createBPAComponents resolves', t5 => {
-          createATCCard.resolves();
-          createBPAComponents.resolves();
+        t4.test('createATCCard resolves', t5 => {
+          t5.test('createBPAComponents rejects', t6 => {
+            const err = new Error('Test error');
+            addIntakeChecklist.resolves();
+            createATCCard.resolves();
+            createBPAComponents.rejects(err);
 
-          moveToiaaGo(trelloEvent)
-            .then(() => {
-              t5.pass('resolves');
-            })
-            .catch(() => {
-              t5.fail('resolves');
-            })
-            .then(t5.done);
+            moveToiaaGo(trelloEvent)
+              .then(() => {
+                t6.fail('rejects');
+              })
+              .catch(e => {
+                t6.pass('rejects');
+                t6.equal(e, err, 'returns the expected error');
+              })
+              .then(t6.done);
+          });
+
+          t5.test('createBPAComponents resolves', t6 => {
+            addIntakeChecklist.resolves();
+            createATCCard.resolves();
+            createBPAComponents.resolves();
+
+            moveToiaaGo(trelloEvent)
+              .then(() => {
+                t6.pass('resolves');
+              })
+              .catch(() => {
+                t6.fail('resolves');
+              })
+              .then(t6.done);
+          });
+
+          t5.done();
         });
 
         t4.done();

--- a/test/webhookHandlers/move-to-iaa-go.js
+++ b/test/webhookHandlers/move-to-iaa-go.js
@@ -9,8 +9,11 @@ process.env.TRELLO_API_KEY = 'trello-api-key';
 process.env.TRELLO_API_TOK = 'trello-api-tok';
 
 const sandbox = sinon.sandbox.create();
+const addIntakeChecklist = sandbox.stub().resolves();
 const createATCCard = sandbox.stub();
 const createBPAComponents = sandbox.stub();
+
+mockRequire('../../webhookHandlers/intake/move-to-iaa-go/create-checklists-on-intake-card', addIntakeChecklist);
 mockRequire('../../webhookHandlers/intake/move-to-iaa-go/create-atc-card', createATCCard);
 mockRequire('../../webhookHandlers/intake/move-to-iaa-go/create-bpa-components', createBPAComponents);
 

--- a/test/webhookHandlers/move-to-iaa-go/create-checklists-on-intake-card.js
+++ b/test/webhookHandlers/move-to-iaa-go/create-checklists-on-intake-card.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const tap = require('tap');
+const sinon = require('sinon');
+require('sinon-as-promised');
+const mockRequire = require('mock-require');
+
+const sandbox = sinon.sandbox.create();
+const addChecklistAction = sandbox.stub();
+
+mockRequire('../../../actions', {
+  addIntakeChecklist: addChecklistAction
+});
+
+// Disable logging to the console.
+require('@erdc-itl/simple-logger').setOptions({ console: false });
+
+const createChecklistHandler = require('../../../webhookHandlers/intake/move-to-iaa-go/create-checklists-on-intake-card');
+const trelloEvent = {
+  action: { data: { card: { id: 'intake-card-id' }}}
+};
+
+tap.test('webhook handlers - intake: move to IAA Go > create checklist on intake card', t1 => {
+  tap.beforeEach(done => {
+    sandbox.reset();
+    done();
+  });
+  tap.teardown(() => {
+    sandbox.restore();
+  });
+
+  t1.test('add intake checklist action rejects', t2 => {
+    const err = new Error('Test error');
+    addChecklistAction.rejects(err);
+
+    createChecklistHandler(trelloEvent)
+      .then(() => {
+        t2.fail('rejects');
+      })
+      .catch(e => {
+        t2.pass('rejects');
+        t2.equal(addChecklistAction.callCount, 1, 'calls add intake checklist action one time');
+        t2.equal(addChecklistAction.args[0][0], trelloEvent.action.data.card.id, 'passes the card ID');
+        t2.equal(e, err, 'returns the expected error');
+      })
+      .then(t2.done);
+  });
+
+  t1.test('add intake checklist action resolves', t2 => {
+    addChecklistAction.resolves();
+
+    createChecklistHandler(trelloEvent)
+      .then(() => {
+        t2.pass('resolves');
+        t2.equal(addChecklistAction.callCount, 1, 'calls add intake checklist action one time');
+        t2.equal(addChecklistAction.args[0][0], trelloEvent.action.data.card.id, 'passes the card ID');
+      })
+      .catch(e => {
+        t2.fail('resolves');
+      })
+      .then(t2.done);
+  });
+
+  t1.done();
+});

--- a/webhookHandlers/intake/move-to-iaa-go.js
+++ b/webhookHandlers/intake/move-to-iaa-go.js
@@ -5,12 +5,14 @@ const actions = require('../../actions');
 const eventTypes = require('../event-types');
 const log = require('../../logger')('intake handler: IAA Go');
 
-const createBPAComponents = require('./move-to-iaa-go/create-bpa-components');
+const createChecklists = require('./move-to-iaa-go/create-checklists-on-intake-card');
 const createATCCard = require('./move-to-iaa-go/create-atc-card');
+const createBPAComponents = require('./move-to-iaa-go/create-bpa-components');
 
 module.exports = function handleIntakeWebhookEvent(e) {
   if (eventTypes(e) === eventTypes.CardMoved && e.action.data.listAfter.name.startsWith('IAA Go')) {
-    return createATCCard(e)
+    return createChecklists(e)
+      .then(() => createATCCard(e))
       .then(() => createBPAComponents(e))
   } else {
     return Promise.reject(new Error('Not a move to IAA Go'));

--- a/webhookHandlers/intake/move-to-iaa-go/create-checklists-on-intake-card.js
+++ b/webhookHandlers/intake/move-to-iaa-go/create-checklists-on-intake-card.js
@@ -4,5 +4,5 @@ const trello = require('../../../trello');
 const actions = require('../../../actions');
 
 module.exports = function createChecklists(e) {
-  return Promise.resolve();
+  return actions.addIntakeChecklist(e.action.data.card.id);
 };

--- a/webhookHandlers/intake/move-to-iaa-go/create-checklists-on-intake-card.js
+++ b/webhookHandlers/intake/move-to-iaa-go/create-checklists-on-intake-card.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const trello = require('../../../trello');
 const actions = require('../../../actions');
 
 module.exports = function createChecklists(e) {

--- a/webhookHandlers/intake/move-to-iaa-go/create-checklists-on-intake-card.js
+++ b/webhookHandlers/intake/move-to-iaa-go/create-checklists-on-intake-card.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const trello = require('../../../trello');
+const actions = require('../../../actions');
+
+module.exports = function createChecklists(e) {
+  return Promise.resolve();
+};


### PR DESCRIPTION
When an intake card is moved to the IAA Go list, adds IAA document checklist to the card.  Also includes :all_the_tests:
